### PR TITLE
Added rate control, prevented duff magnetometer reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.swp
+*.swo
+.DS_Store

--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -343,10 +343,6 @@ bool Adafruit_LSM303_Mag_Unified::begin()
     return false;
   }
 
-  // maximum frequency
-  reg1_a = 0x1c;
-  write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_CRA_REG_M, reg1_a);
-  
   // Set the gain to a known level
   setMagGain(LSM303_MAGGAIN_1_3);
 
@@ -406,6 +402,18 @@ void Adafruit_LSM303_Mag_Unified::setMagGain(lsm303MagGain gain)
       break;
   } 
 }
+
+/**************************************************************************/
+/*!
+    @brief  Sets the magnetometer's update rate
+*/
+/**************************************************************************/
+void Adafruit_LSM303_Mag_Unified::setMagRate(lsm303MagRate rate)
+{
+	byte reg_m = ((byte)rate & 0x07) << 2;
+  write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_CRA_REG_M, reg_m);
+}
+
 
 /**************************************************************************/
 /*! 

--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -167,7 +167,7 @@ bool Adafruit_LSM303_Accel_Unified::begin()
     @brief  Gets the most recent sensor event
 */
 /**************************************************************************/
-void Adafruit_LSM303_Accel_Unified::getEvent(sensors_event_t *event) {
+bool Adafruit_LSM303_Accel_Unified::getEvent(sensors_event_t *event) {
   /* Clear the event */
   memset(event, 0, sizeof(sensors_event_t));
   
@@ -181,6 +181,8 @@ void Adafruit_LSM303_Accel_Unified::getEvent(sensors_event_t *event) {
   event->acceleration.x = _accelData.x * _lsm303Accel_MG_LSB * SENSORS_GRAVITY_STANDARD;
   event->acceleration.y = _accelData.y * _lsm303Accel_MG_LSB * SENSORS_GRAVITY_STANDARD;
   event->acceleration.z = _accelData.z * _lsm303Accel_MG_LSB * SENSORS_GRAVITY_STANDARD;
+
+	return true;
 }
 
 /**************************************************************************/
@@ -410,7 +412,7 @@ void Adafruit_LSM303_Mag_Unified::setMagGain(lsm303MagGain gain)
     @brief  Gets the most recent sensor event
 */
 /**************************************************************************/
-void Adafruit_LSM303_Mag_Unified::getEvent(sensors_event_t *event) {
+bool Adafruit_LSM303_Mag_Unified::getEvent(sensors_event_t *event) {
   bool readingValid = false;
   
   /* Clear the event */
@@ -419,11 +421,10 @@ void Adafruit_LSM303_Mag_Unified::getEvent(sensors_event_t *event) {
   while(!readingValid)
   {
 
-      uint8_t reg_mg = read8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_SR_REG_Mg);
-      if (!(reg_mg & 0x1))
-      {
-        continue;
-      }
+    uint8_t reg_mg = read8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_SR_REG_Mg);
+    if (!(reg_mg & 0x1)) {
+			return false;
+    }
   
     /* Read new data */
     read();
@@ -496,6 +497,8 @@ void Adafruit_LSM303_Mag_Unified::getEvent(sensors_event_t *event) {
   event->magnetic.x = _magData.x / _lsm303Mag_Gauss_LSB_XY * SENSORS_GAUSS_TO_MICROTESLA;
   event->magnetic.y = _magData.y / _lsm303Mag_Gauss_LSB_XY * SENSORS_GAUSS_TO_MICROTESLA;
   event->magnetic.z = _magData.z / _lsm303Mag_Gauss_LSB_Z * SENSORS_GAUSS_TO_MICROTESLA;
+		
+	return true;
 }
 
 /**************************************************************************/

--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -340,6 +340,10 @@ bool Adafruit_LSM303_Mag_Unified::begin()
   {
     return false;
   }
+
+  // maximum frequency
+  reg1_a = 0x1c;
+  write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_CRA_REG_M, reg1_a);
   
   // Set the gain to a known level
   setMagGain(LSM303_MAGGAIN_1_3);
@@ -414,6 +418,13 @@ void Adafruit_LSM303_Mag_Unified::getEvent(sensors_event_t *event) {
   
   while(!readingValid)
   {
+
+      uint8_t reg_mg = read8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_SR_REG_Mg);
+      if (!(reg_mg & 0x1))
+      {
+        continue;
+      }
+  
     /* Read new data */
     read();
     

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -109,13 +109,13 @@
     typedef enum
     {
       LSM303_MAGRATE_0_7                        = 0x00,  // 0.75 Hz
-      LSM303_MAGGAIN_1_5                        = 0x01,  // 1.5 Hz
-      LSM303_MAGGAIN_3_0                        = 0x62,  // 3.0 Hz
-      LSM303_MAGGAIN_7_5                        = 0x03,  // 7.5 Hz
-      LSM303_MAGGAIN_15                         = 0x04,  // 15 Hz
-      LSM303_MAGGAIN_30                         = 0x05,  // 30 Hz
-      LSM303_MAGGAIN_75                         = 0x06,  // 75 Hz
-      LSM303_MAGGAIN_220                        = 0x07   // 200 Hz
+      LSM303_MAGRATE_1_5                        = 0x01,  // 1.5 Hz
+      LSM303_MAGRATE_3_0                        = 0x62,  // 3.0 Hz
+      LSM303_MAGRATE_7_5                        = 0x03,  // 7.5 Hz
+      LSM303_MAGRATE_15                         = 0x04,  // 15 Hz
+      LSM303_MAGRATE_30                         = 0x05,  // 30 Hz
+      LSM303_MAGRATE_75                         = 0x06,  // 75 Hz
+      LSM303_MAGRATE_220                        = 0x07   // 200 Hz
     } lsm303MagRate;	
 /*=========================================================================*/
 
@@ -127,7 +127,6 @@
         float x;
         float y;
         float z;
-      float orientation;
     } lsm303MagData;
 /*=========================================================================*/
 

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -139,7 +139,7 @@ class Adafruit_LSM303_Accel_Unified : public Adafruit_Sensor
     Adafruit_LSM303_Accel_Unified(int32_t sensorID = -1);
   
     bool begin(void);
-    void getEvent(sensors_event_t*);
+    bool getEvent(sensors_event_t*);
     void getSensor(sensor_t*);
 
   private:
@@ -160,7 +160,7 @@ class Adafruit_LSM303_Mag_Unified : public Adafruit_Sensor
     bool begin(void);
     void enableAutoRange(bool enable);
     void setMagGain(lsm303MagGain gain);
-    void getEvent(sensors_event_t*);
+    bool getEvent(sensors_event_t*);
     void getSensor(sensor_t*);
 
   private:

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -104,6 +104,22 @@
 /*=========================================================================*/
 
 /*=========================================================================
+    MAGNETOMETER UPDATE RATE SETTINGS
+    -----------------------------------------------------------------------*/
+    typedef enum
+    {
+      LSM303_MAGRATE_0_7                        = 0x00,  // 0.75 Hz
+      LSM303_MAGGAIN_1_5                        = 0x01,  // 1.5 Hz
+      LSM303_MAGGAIN_3_0                        = 0x62,  // 3.0 Hz
+      LSM303_MAGGAIN_7_5                        = 0x03,  // 7.5 Hz
+      LSM303_MAGGAIN_15                         = 0x04,  // 15 Hz
+      LSM303_MAGGAIN_30                         = 0x05,  // 30 Hz
+      LSM303_MAGGAIN_75                         = 0x06,  // 75 Hz
+      LSM303_MAGGAIN_220                        = 0x07   // 200 Hz
+    } lsm303MagRate;	
+/*=========================================================================*/
+
+/*=========================================================================
     INTERNAL MAGNETOMETER DATA TYPE
     -----------------------------------------------------------------------*/
     typedef struct lsm303MagData_s
@@ -160,6 +176,7 @@ class Adafruit_LSM303_Mag_Unified : public Adafruit_Sensor
     bool begin(void);
     void enableAutoRange(bool enable);
     void setMagGain(lsm303MagGain gain);
+    void setMagRate(lsm303MagRate rate);
     bool getEvent(sensors_event_t*);
     void getSensor(sensor_t*);
 


### PR DESCRIPTION
The LSM303 mag registers aren't valid if DRDY isn't set in the status register.  Once set they'll remain valid until all registers are read.  If data is read whilst the LSM303 writes to those registers it'll be junk.  I could have opted to read in a loop until DRDY is set, but depending on the rate set for updates that can be a long time and will prevent other data being processed (e.g. the serial buffer may overflow whilst the magnetometer code spins polling).  Instead I added the ability for getEvent to fail meaning there's no valid data.  I'll also generate a related pull request on Adafruit_Sensor.

Additionally added ability to set the update rate on the magnetometer.