### PR TITLE
Set rate fix

### DIFF
--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -422,7 +422,7 @@ void Adafruit_LSM303_Mag_Unified::setMagGain(lsm303MagGain gain)
 /**************************************************************************/
 void Adafruit_LSM303_Mag_Unified::setMagRate(lsm303MagRate rate)
 {
-	byte reg_m = ((byte)rate & 0x07) << 2;
+	byte reg_m = ((byte)rate & 0x1C);
   write8(LSM303_ADDRESS_MAG, LSM303_REGISTER_MAG_CRA_REG_M, reg_m);
 }
 

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -109,14 +109,14 @@
     -----------------------------------------------------------------------*/
     typedef enum
     {
-      LSM303_MAGRATE_0_7                        = 0x00,  // 0.75 Hz
-      LSM303_MAGRATE_1_5                        = 0x01,  // 1.5 Hz
-      LSM303_MAGRATE_3_0                        = 0x02,  // 3.0 Hz
-      LSM303_MAGRATE_7_5                        = 0x03,  // 7.5 Hz
-      LSM303_MAGRATE_15                         = 0x04,  // 15 Hz
-      LSM303_MAGRATE_30                         = 0x05,  // 30 Hz
-      LSM303_MAGRATE_75                         = 0x06,  // 75 Hz
-      LSM303_MAGRATE_220                        = 0x07   // 200 Hz
+      LSM303_MAGRATE_0_7                        = ( 0x00 << 2 ),  // 0.75 Hz
+      LSM303_MAGRATE_1_5                        = ( 0x01 << 2 ),  // 1.5 Hz 
+      LSM303_MAGRATE_3_0                        = ( 0x02 << 2 ),  // 3.0 Hz 
+      LSM303_MAGRATE_7_5                        = ( 0x03 << 2 ),  // 7.5 Hz 
+      LSM303_MAGRATE_15                         = ( 0x04 << 2 ),  // 15 Hz 
+      LSM303_MAGRATE_30                         = ( 0x05 << 2 ),  // 30 Hz 
+      LSM303_MAGRATE_75                         = ( 0x06 << 2 ),  // 75 Hz 
+      LSM303_MAGRATE_220                        = ( 0x07 << 2 )   // 200 Hz 
     } lsm303MagRate;
 /*=========================================================================*/
 

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -111,7 +111,7 @@
     {
       LSM303_MAGRATE_0_7                        = 0x00,  // 0.75 Hz
       LSM303_MAGRATE_1_5                        = 0x01,  // 1.5 Hz
-      LSM303_MAGRATE_3_0                        = 0x62,  // 3.0 Hz
+      LSM303_MAGRATE_3_0                        = 0x02,  // 3.0 Hz
       LSM303_MAGRATE_7_5                        = 0x03,  // 7.5 Hz
       LSM303_MAGRATE_15                         = 0x04,  // 15 Hz
       LSM303_MAGRATE_30                         = 0x05,  // 30 Hz


### PR DESCRIPTION
This change fixes a bad value in the defined values for the magnetometer's sample rate.  The 3.0Hz rate had an erroneous '6' in the MSBs.

Additionally, I converted these defined values to be ones that can be directly written to the LSM303's registers, rather than requiring a bit shift as they did before.  This was done because now a user can bitwise OR these values with values for the bottom two bits (if they wish to set them) instead of first having to shift the values.

There's no code speedup associated with the shifts, as the containing function is only run when the value is set.  This change is more about convention.

Hopefully that is sufficient information for the request!
